### PR TITLE
Update Full Metal Daemon Muramasa's compatibility and guide

### DIFF
--- a/docs/public/vn_list.json
+++ b/docs/public/vn_list.json
@@ -850,6 +850,7 @@
     "Wineprefix": "proton-ge",
     "Wine version": "Proton GE 11.1",
     "Notes": "[]"
+    "Update Date": "07-04-2026"
   },
   {
     "Visual Novel": "AIR",

--- a/docs/public/vn_list.json
+++ b/docs/public/vn_list.json
@@ -848,8 +848,8 @@
     "Steam Deck": "✅",
     "Game engine": "N2System/N4System",
     "Wineprefix": "proton-ge",
-    "Wine version": "Proton GE 10.27",
-    "Notes": "[122]"
+    "Wine version": "Proton GE 11.1",
+    "Notes": "[]"
   },
   {
     "Visual Novel": "AIR",

--- a/docs/visual-novels/full-metal-daemon-muramasa.md
+++ b/docs/visual-novels/full-metal-daemon-muramasa.md
@@ -7,47 +7,26 @@ title : 'Full Metal Daemon: Muramasa'
 
 ### Linux
 
-> [!info] Requirements
-> Lutris have to be installed and [muramasafiles_lite](https://drive.google.com/file/d/1EF2YSQkTAY6FuIwH-xbSrZF8UNYnYmtA/view?usp=share_link) downloaded.
+#### Lutris 
 
-> [!warning] Warning
-> **muramasafiles_lite** is a repackaged version of these files: [mf-install](https://github.com/z0z0z/mf-install), [mf-installcab](https://github.com/z0z0z/mf-installcab) [XAudio2 (x86)](https://www.nuget.org/packages/Microsoft.XAudio2.Redist/). This **XAudio2 .nupkg** should contain **xaudio2_9redist.dll** in **build\native\debug\bin\x86**. It’s been renamed to **xaudio2_8.dll** for Muramasa (and other visual novels that may use it) specifically.
+> [!info] Information
+> Tested with [Lutris-GE-Proton 11-1](/linux/adding-wine-versions).
 
-Follow these instructions to make movies play.
+* In "Game info", select "Wine" for "Runner"
+* In "Game options", select the proton-ge folder for "Wine prefix" and "yourgame.exe" for "Executable"
+* In "Runner options", select "GE-Proton11-1".
 
-1. Unpack muramasafiles_lite
+#### Steam
 
-You’ll get a folder called mf-install-muramasa. Right click the **mf-install-muramas**a folder and **Copy Location**.
-
-2. Setting up Lutris settings
-Click **+** then **Add locally installed game** with these settings:
-
-* Game info
-  * **Runner**, select **Wine**
-* Game options
-  * **Wine prefix**, make a new vanilla wineprefix folder and set it to that you can name it "muramasaengine" for example
-  * **Wine architecture**, select **64bit**.
-* Runner options
-  * **Wine version**, select the default **Lutris 7.2** version.
-  * Turn on DXVK
-  * Turn off Fsync and Esync
-
-3. Install mf-install.sh in Bash Terminal
-
-Click the Wine bottle on the bottom and click Bash Terminal. Once it’s open, run these commands.
-
-```
-cd <path to the mf-install-muramasa folder>
-sh ./mf-install.sh
-```
-
-Be sure to replace the path with the **mf-install** folder’s path (the folder you did **Copy Location** on)
+* Add the game as a non Steam game
+* Right-click the game → **Properties → Compatibility** → check "Force the use of a specific Steam Play compatibility tool" → select "GE-Proton11-1".
 
 ### Steam Deck
 
-Same as Linux, but set these settings in-game: 
-* **Resolution**: **1024x576**
-* Turn on **FSR** and **Sharpness** to **5**
+
+Same as Linux, but use these settings: 
+* At launch set **Resolution** to **1024x576**
+* In the game overlay set **Scaling Filter** to **Sharp** and **Sharpness** to **5**
 
 ## Controller configuration
 

--- a/docs/visual-novels/full-metal-daemon-muramasa.md
+++ b/docs/visual-novels/full-metal-daemon-muramasa.md
@@ -23,7 +23,6 @@ title : 'Full Metal Daemon: Muramasa'
 
 ### Steam Deck
 
-
 Same as Linux, but use these settings: 
 * At launch set **Resolution** to **1024x576**
 * In the game overlay set **Scaling Filter** to **Sharp** and **Sharpness** to **5**


### PR DESCRIPTION
I've tested Muramasa for a bit on both my Steam Deck and an old laptop running CachyOS with Proton GE 11.1, I've played through the prologue on the Deck with the game added as a non steam game and I've played through the prologue and finished the 1st chapter on my laptop with the game launched through Lutris, everything behaved like on Windows (the game is also mentioned as working in the [Proton GE 11.1 release](https://github.com/GloriousEggroll/proton-ge-custom/releases#release-GE-Proton11-1)  at the bottom on the verified working test list), if needed I can play further to make sure that everything works fine.